### PR TITLE
Twitter style for opacity

### DIFF
--- a/styles/simple_box_1/style.css
+++ b/styles/simple_box_1/style.css
@@ -154,8 +154,10 @@ padding:1.25em 1.5em 3em 1.5em;
 display:none!important;
 }
 
-#cboxContent #cboxTitle:hover,
-#cboxContent #cboxTitle:hover + #cboxCurrent{
+#cboxOverlay:hover + #colorbox #cboxTitle,
+#cboxOverlay:hover + #colorbox #cboxTitle + #cboxCurrent,
+#cboxOverlay:hover + #colorbox #cboxTitle ~ button
+{
 opacity:0;
 }
 


### PR DESCRIPTION
Twitter style for control elements and title opacity. Hover background to hide all labels. Saves possibility to copy title.